### PR TITLE
Default issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Standard template for reporting bugs
+title: ''
+labels: 'bug'
+assignees: ''
+
+---
+
+## Bug description
+<!-- A clear and concise description of the bug. -->
+
+## Expected behaviour
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Is reproducible
+Yes/No 
+
+## To reproduce
+<!--  Provide the exact steps to reproduce the behaviour-->
+
+## Steps taken to try to reproduce
+<!-- Share what you've tried, but didn't solve the issue -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Version information:
+- Package version:
+- Python version:
+
+## Additional information
+<!-- Any other information and context that can help with resolving the bug faster. -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,23 @@
+---
+name: Enhancement request
+about: Standard template for enhancement requests
+title: ''
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Enhancement description
+<!-- A clear description of the enhancement. -->
+
+## The problem it solves
+<!-- Explain how you will benefit from this enhancement. -->
+
+## Alternatives
+<!-- If applicable, share which workarounds can currently apply. -->
+
+## Use case / screenshots
+<!-- Add use cases or screenshots related to the enhancement request here. -->
+
+## Additional information
+<!-- Add any additional information that may be useful. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Standard template for reporting questions
+title: ''
+labels: 'question'
+assignees: ''
+
+---
+
+## Question description
+<!-- A clear and concise description of the question. -->


### PR DESCRIPTION
As discussed in a few places, adding default templates that we use within Doist for basic kinds of tickets. Once approved and merged, I will also add them to the typescript SDK repo :-)