### PR TITLE
Add support to datetime objects

### DIFF
--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -1,3 +1,4 @@
+from datetime import date, datetime
 from typing import Any, Dict, List
 
 import requests
@@ -55,6 +56,11 @@ class TodoistAPI:
 
     def add_task(self, content: str, **kwargs) -> Task:
         endpoint = get_rest_url(TASKS_ENDPOINT)
+
+        for key, value in kwargs.items():
+            if isinstance(value, (date, datetime)):
+                kwargs[key] = value.isoformat()
+
         data: Dict[str, Any] = {"content": content}
         data.update(kwargs)
         task = post(self._session, endpoint, self._token, data=data)


### PR DESCRIPTION
The code checks if the object is "datetime.datetime" or "datetime.date", then produce a serialized version. It is useful for developers to avoid string casting, because avoids TypeError raised by "Object of type date is not JSON serializable". 