### PR TITLE
Improved type annotations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterator, List
 
 import pytest
 import responses
@@ -34,7 +34,7 @@ from todoist_api_python.models import (
 
 
 @pytest.fixture()
-def requests_mock() -> responses.RequestsMock:
+def requests_mock() -> Iterator[responses.RequestsMock]:
     with responses.RequestsMock() as requestsMock:
         yield requestsMock
 

--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import requests
 
@@ -33,7 +33,7 @@ def _validate_entity_id(value: int):
 
 
 class TodoistAPI:
-    def __init__(self, token: str, session=None):
+    def __init__(self, token: str, session: Optional[requests.Session] = None) -> None:
         self._token: str = token
         self._session = session or requests.Session()
 

--- a/todoist_api_python/api_async.py
+++ b/todoist_api_python/api_async.py
@@ -14,7 +14,7 @@ from todoist_api_python.utils import run_async
 
 
 class TodoistAPIAsync:
-    def __init__(self, token: str):
+    def __init__(self, token: str) -> None:
         self._api = TodoistAPI(token)
 
     async def get_task(self, task_id: int) -> Task:


### PR DESCRIPTION
This PR fixes a mypy error

```
tests/conftest.py:37: error: The return type of a generator function should be "Generator" or one of its supertypes
Found 1 error in 1 file (checked 24 source files)
```

and adds missing annotations to API clients (TodoistAPI and TodoistAPIAsync).