### PR TITLE
fix: Fix a crash when comment attachment is null.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,14 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2022-09-08
+
+Migrate to [REST API v2](https://developer.todoist.com/rest/v2/?python).
+
 ## [1.1.1] - 2022-02-15
+
 ### Fixes
+
 - Add missing `attrs` package dependency
 
 ### Security
+
 - Dependabot updates
 
-
 ## [1.1.0] - 2021-11-23
+
 ### Added
+
 - Public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fixed a crash in `get_comments` if attachment is null.
+
 ## [2.0.0] - 2022-09-08
 
 Migrate to [REST API v2](https://developer.todoist.com/rest/v2/?python).

--- a/tests/data/test_defaults.py
+++ b/tests/data/test_defaults.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+from typing import Any
+
 REST_API_BASE_URL = "https://api.todoist.com/rest/v2"
 SYNC_API_BASE_URL = "https://api.todoist.com/sync/v9"
 AUTH_BASE_URL = "https://todoist.com"
@@ -107,7 +110,7 @@ DEFAULT_ATTACHMENT_RESPONSE = {
     "title": "Todoist Website",
 }
 
-DEFAULT_COMMENT_RESPONSE = {
+DEFAULT_COMMENT_RESPONSE: dict[str, Any] = {
     "id": "1234",
     "content": "A comment",
     "posted_at": "2016-09-22T07:00:00.00000Z",
@@ -118,6 +121,7 @@ DEFAULT_COMMENT_RESPONSE = {
 
 DEFAULT_COMMENT_RESPONSE_2 = dict(DEFAULT_COMMENT_RESPONSE)
 DEFAULT_COMMENT_RESPONSE_2["id"] = "5678"
+DEFAULT_COMMENT_RESPONSE_2["attachment"] = None
 
 DEFAULT_COMMENTS_RESPONSE = [
     DEFAULT_COMMENT_RESPONSE,

--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -315,7 +315,7 @@ class Comment(object):
     def from_dict(cls, obj):
         attachment: Attachment | None = None
 
-        if "attachment" in obj:
+        if "attachment" in obj and obj["attachment"] is not None:
             attachment = Attachment.from_dict(obj["attachment"])
 
         return cls(


### PR DESCRIPTION
Fix https://github.com/Doist/Issues/issues/7894

The crash was introduced in V2 API migration (2.0.0). REST V2 API returns `attachment: null` where V1 ommitted the value.