### PR TITLE
Restore Python 3.9 version compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -64,6 +64,8 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -279,6 +281,7 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=3.10"
 
 [package.extras]
@@ -671,5 +674,5 @@ testing = ["coverage (>=6.2)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.11.4"
-content-hash = "d40ca506fd1aebf61e496476f9893efe23190e91b3c922966c02db908bed5ae5"
+python-versions = "^3.9"
+content-hash = "3f9b34bd049c277f51cd87be4b85dea774c566a8f53f23d79304520241fe1bae"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.11.4"
+python = "^3.9"
 requests = "^2.26.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
https://github.com/Doist/todoist-api-python/pull/99#pullrequestreview-1573783238 accidentally (?) removed compatibility with any Python version up to `3.11.4`.
This blocks us from using `v2.1.1` for Home-Assistant even though we are already using `>=3.11.0`.

/CC @lefcha 