### PR TITLE
Default value to section id

### DIFF
--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -154,7 +154,7 @@ class Task(object):
             parent_id=obj.get("parent_id"),
             priority=obj["priority"],
             project_id=obj["project_id"],
-            section_id=obj["section_id"],
+            section_id=obj.get("section_id", None),
             url=obj["url"],
         )
 


### PR DESCRIPTION
Task.from_dict: section_id defaults to **None** if the key doesn't exist in **obj**

Fixies #93 