### PR TITLE
Upgrade pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: debug-statements
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
 


### PR DESCRIPTION
* [https://github.com/pre-commit/pre-commit-hooks] already up to date!
* [https://github.com/psf/black] updating 23.7.0 -> 23.9.1
* [https://github.com/PyCQA/isort] already up to date!
* [https://github.com/pycqa/flake8] already up to date!