### PR TITLE
Properly close requests Session object

### DIFF
--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
+from weakref import finalize
+
 import requests
 
 from todoist_api_python.endpoints import (
@@ -36,6 +38,13 @@ class TodoistAPI:
     def __init__(self, token: str, session: requests.Session | None = None) -> None:
         self._token: str = token
         self._session = session or requests.Session()
+        self._finalizer = finalize(self, self._session.close)
+        
+    def __enter__(self):
+            return self
+        
+    def __exit__(self, exc_type, exc_value, traceback):
+            self._finalizer()
 
     def get_task(self, task_id: str) -> Task:
         endpoint = get_rest_url(f"{TASKS_ENDPOINT}/{task_id}")

--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -41,10 +41,10 @@ class TodoistAPI:
         self._finalizer = finalize(self, self._session.close)
         
     def __enter__(self):
-            return self
+        return self
         
     def __exit__(self, exc_type, exc_value, traceback):
-            self._finalizer()
+        self._finalizer()
 
     def get_task(self, task_id: str) -> Task:
         endpoint = get_rest_url(f"{TASKS_ENDPOINT}/{task_id}")


### PR DESCRIPTION
In the current implementation of the TodoistAPI class, self._session is not closed properly when its scope ends. Depending on how this library is used, it could lead to performance degradation or resource leaks. Consider allowing the class to be used in a context manager by defining `__enter__` and `__exit__` methods and creating a [finalizer object](https://docs.python.org/3/library/weakref.html#finalizer-objects) property to clean up the Session object in the event of an exception or the program's end.