### PR TITLE
feat: Support project.can_assign_tasks

### DIFF
--- a/tests/data/test_defaults.py
+++ b/tests/data/test_defaults.py
@@ -56,6 +56,7 @@ DEFAULT_PROJECT_RESPONSE = {
     "is_favorite": False,
     "is_inbox_project": True,
     "is_team_inbox": True,
+    "allow_assignment": False,
     "url": "https://todoist.com/showProject?id=1234",
     "view_style": "list",
 }

--- a/tests/data/test_defaults.py
+++ b/tests/data/test_defaults.py
@@ -56,7 +56,7 @@ DEFAULT_PROJECT_RESPONSE = {
     "is_favorite": False,
     "is_inbox_project": True,
     "is_team_inbox": True,
-    "allow_assignment": False,
+    "can_assign_tasks": False,
     "url": "https://todoist.com/showProject?id=1234",
     "view_style": "list",
 }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,6 +52,7 @@ def test_project_from_dict():
     assert project.order == sample_data["order"]
     assert project.parent_id == sample_data["parent_id"]
     assert project.view_style == sample_data["view_style"]
+    assert project.allow_assignment == sample_data["allow_assignment"]
 
 
 def test_section_from_dict():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -52,7 +52,7 @@ def test_project_from_dict():
     assert project.order == sample_data["order"]
     assert project.parent_id == sample_data["parent_id"]
     assert project.view_style == sample_data["view_style"]
-    assert project.allow_assignment == sample_data["allow_assignment"]
+    assert project.can_assign_tasks == sample_data["can_assign_tasks"]
 
 
 def test_section_from_dict():

--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -17,7 +17,7 @@ class Project:
     is_inbox_project: bool
     is_shared: bool
     is_team_inbox: bool
-    allow_assignment: bool
+    can_assign_tasks: bool
     name: str
     order: int
     parent_id: str | None
@@ -34,7 +34,7 @@ class Project:
             is_inbox_project=obj.get("is_inbox_project"),
             is_shared=obj["is_shared"],
             is_team_inbox=obj.get("is_team_inbox"),
-            allow_assignment=obj["allow_assignment"],
+            can_assign_tasks=obj["can_assign_tasks"],
             name=obj["name"],
             order=obj.get("order"),
             parent_id=obj.get("parent_id"),

--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -17,6 +17,7 @@ class Project:
     is_inbox_project: bool
     is_shared: bool
     is_team_inbox: bool
+    allow_assignment: bool
     name: str
     order: int
     parent_id: str | None
@@ -33,6 +34,7 @@ class Project:
             is_inbox_project=obj.get("is_inbox_project"),
             is_shared=obj["is_shared"],
             is_team_inbox=obj.get("is_team_inbox"),
+            allow_assignment=obj["allow_assignment"],
             name=obj["name"],
             order=obj.get("order"),
             parent_id=obj.get("parent_id"),


### PR DESCRIPTION
## Context

Supports the change coming from https://github.com/Doist/Todoist/pull/15002 where we are adding a `project.can_assign_tasks` flag with the following logic:

- `can_assign_tasks` would be `true` for shared personal projects (and becomes `false` when the project becomes unshared)
- `can_assign_tasks` would be `true` for all workspace projects

This flag will help resolve https://github.com/Doist/Issues/issues/11930

## Refs

- https://github.com/Doist/Todoist/pull/15002
- https://github.com/Doist/Issues/issues/11930
