### PR TITLE
fix: key error on can_assign_tasks in Project model

### DIFF
--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -34,7 +34,7 @@ class Project:
             is_inbox_project=obj.get("is_inbox_project"),
             is_shared=obj["is_shared"],
             is_team_inbox=obj.get("is_team_inbox"),
-            can_assign_tasks=obj["can_assign_tasks"],
+            can_assign_tasks=obj.get("can_assign_tasks"),
             name=obj["name"],
             order=obj.get("order"),
             parent_id=obj.get("parent_id"),


### PR DESCRIPTION
Used get to prevent key error when accessing Project APIs. This fixes #135.