### PR TITLE
Add deadline support

### DIFF
--- a/tests/data/test_defaults.py
+++ b/tests/data/test_defaults.py
@@ -26,6 +26,11 @@ DEFAULT_DUE_RESPONSE = {
     "is_recurring": True,
 }
 
+DEFAULT_DEADLINE_RESPONSE = {
+    "date": "2016-09-01",
+    "lang": "en",
+}
+
 DEFAULT_DURATION_RESPONSE = {
     "amount": 60,
     "unit": "minute",
@@ -37,6 +42,7 @@ DEFAULT_META_RESPONSE: dict[str, Any] = {
     "assignee": [None, None],
     "labels": {},
     "due": None,
+    "deadline": None,
 }
 
 DEFAULT_PROJECT_RESPONSE = {
@@ -88,6 +94,7 @@ DEFAULT_TASK_RESPONSE: dict[str, Any] = {
     "labels": [],
     "priority": 1,
     "due": DEFAULT_DUE_RESPONSE,
+    "deadline": DEFAULT_DEADLINE_RESPONSE,
     "duration": DEFAULT_DURATION_RESPONSE,
     "collapsed": False,
     "child_order": 3,

--- a/todoist_api_python/models.py
+++ b/todoist_api_python/models.py
@@ -75,6 +75,15 @@ class Due(JSONPyWizard):
 
 
 @dataclass
+class Deadline(JSONPyWizard):
+    class _(JSONPyWizard.Meta):  # noqa:N801
+        v1 = True
+
+    date: ApiDue
+    lang: str = "en"
+
+
+@dataclass
 class Meta(JSONPyWizard):
     class _(JSONPyWizard.Meta):  # noqa:N801
         v1 = True
@@ -84,6 +93,7 @@ class Meta(JSONPyWizard):
     assignee: tuple[str, str]
     labels: dict[int, str]
     due: Due | None
+    deadline: Deadline | None
 
 
 @dataclass
@@ -100,6 +110,7 @@ class Task(JSONPyWizard):
     labels: list[str] | None
     priority: int
     due: Due | None
+    deadline: Deadline | None
     duration: Duration | None
     is_collapsed: Annotated[bool, Alias(load=("collapsed", "is_collapsed"))]
     order: Annotated[int, Alias(load=("child_order", "order"))]


### PR DESCRIPTION
Deadline was already supported when creating and updating tasks since the migration to the Todoist API v1.

It is now also returned on the Task object.

Closes #165