### PR TITLE
Set asyncio_default_fixture_loop_scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,3 +150,6 @@ convention = "pep257"
 
 [tool.ruff.format]
 docstring-code-format = true
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"


### PR DESCRIPTION
This is now expected, see https://github.com/pytest-dev/pytest-asyncio/issues/924.

Otherwise, a warning is raised.