### PR TITLE
Add the `backups:read` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for moving tasks, courtesy of @radiant-tangent
+- Support for `backups:read` scope
 - Re-add support for `X-Request-ID`
   - Configurable via `request_id_fn` API constructor argument
   - Defaults to random UUID v4

--- a/todoist_api_python/authentication.py
+++ b/todoist_api_python/authentication.py
@@ -17,23 +17,23 @@ from todoist_api_python._core.http_requests import delete, post
 from todoist_api_python._core.utils import run_async
 from todoist_api_python.models import AuthResult
 
-# task:add - Only create new tasks
-# data:read - Read-only access
-# data:read_write - Read and write access
-# data:delete - Full access including delete
-# project:delete - Can delete projects
-
 """
 Possible permission scopes:
 
-- data:read: Read-only access
-- data:read_write: Read and write access
-- data:delete: Full access including delete
-- task:add: Can create new tasks
-- project:delete: Can delete projects
+- `data:read`: Read-only access
+- `data:read_write`: Read and write access
+- `data:delete`: Full access including delete
+- `task:add`: Can create new tasks
+- `project:delete`: Can delete projects
+- `backups:read`: Can access user backups without MFA
 """
 Scope = Literal[
-    "task:add", "data:read", "data:read_write", "data:delete", "project:delete"
+    "task:add",
+    "data:read",
+    "data:read_write",
+    "data:delete",
+    "project:delete",
+    "backups:read",
 ]
 
 


### PR DESCRIPTION
Equivalent to https://github.com/Doist/todoist-api-typescript/pull/287, which I've just come across, but for the Python SDK.

Show PR, I'll merge this once tests are green.