### PR TITLE
Improved logging

### DIFF
--- a/todoist_api_python/_core/http_requests.py
+++ b/todoist_api_python/_core/http_requests.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 from requests.status_codes import codes
 
 from todoist_api_python._core.http_headers import create_headers
+from todoist_api_python._core.utils import log_calls
 
 if TYPE_CHECKING:
     from requests import Session
@@ -22,7 +23,7 @@ TIMEOUT = (10, 60)
 
 T = TypeVar("T")
 
-
+@log_calls
 def get(
     session: Session,
     url: str,
@@ -45,7 +46,7 @@ def get(
     response.raise_for_status()
     return cast("T", response.ok)
 
-
+@log_calls
 def post(
     session: Session,
     url: str,
@@ -73,7 +74,7 @@ def post(
     response.raise_for_status()
     return cast("T", response.ok)
 
-
+@log_calls
 def delete(
     session: Session,
     url: str,

--- a/todoist_api_python/_core/utils.py
+++ b/todoist_api_python/_core/utils.py
@@ -107,7 +107,9 @@ def log_calls(func: Callable[..., T]) -> Callable[..., T]:
     return wrapper
 
 
-def log_method_calls(exclude_dunder: bool = True) -> Callable[[type], type]:
+def log_method_calls(
+    exclude_properties: bool = True, exclude_private: bool = True, exclude_dunder: bool = True
+) -> Callable[[type], type]:
     """
     Class decorator to log calls to all methods of a class. Arguments and returned values are
     included in the log.
@@ -120,6 +122,10 @@ def log_method_calls(exclude_dunder: bool = True) -> Callable[[type], type]:
         for attr_name, attr_value in cls.__dict__.items():
             if callable(attr_value):
                 if exclude_dunder and attr_name.startswith("__") and attr_name.endswith("__"):
+                    continue
+                if exclude_private and attr_name.startswith("_"):
+                    continue
+                if exclude_properties and isinstance(getattr(cls, attr_name, None), property):
                     continue
                 decorated_attr = log_calls(attr_value)
                 setattr(cls, attr_name, decorated_attr)

--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -31,6 +31,7 @@ from todoist_api_python._core.utils import (
     default_request_id_fn,
     format_date,
     format_datetime,
+    log_method_calls
 )
 from todoist_api_python.models import (
     Attachment,
@@ -84,6 +85,7 @@ ColorString = Annotated[
 ViewStyle = Annotated[str, Predicate(lambda x: x in ("list", "board", "calendar"))]
 
 
+@log_method_calls(exclude_dunder=True)
 class TodoistAPI:
     """
     Client for the Todoist API.

--- a/todoist_api_python/api.py
+++ b/todoist_api_python/api.py
@@ -85,7 +85,7 @@ ColorString = Annotated[
 ViewStyle = Annotated[str, Predicate(lambda x: x in ("list", "board", "calendar"))]
 
 
-@log_method_calls(exclude_dunder=True)
+@log_method_calls()
 class TodoistAPI:
     """
     Client for the Todoist API.


### PR DESCRIPTION
Introduced logging to API calls to help debugging

- Uses standard logging module.
- Logs debug level messages for all calls to API methods and for all HTTP requests
- Log messages include function arguments and return values
- No handlers are created - that is the responsibility of the application using the package

To view logs for the test suite:
`uv run pytest --log-file=log.log --log-level=DEBUG`
and open `log.log`

This is something I have in my own copy of this SDK and found useful for recreating bugs in my tools. Log files are quite verbose but easily searchable.